### PR TITLE
Ensure that <|endoftext|> and <|endofcomment|> are single tokens

### DIFF
--- a/subword_nmt/learn_bpe.py
+++ b/subword_nmt/learn_bpe.py
@@ -293,6 +293,7 @@ def learn_bpe(infile, vocab_outfile, encoder_outfile, num_symbols, min_frequency
         if not i % 100:
             prune_stats(stats, big_stats, threshold)
 
+    symbols.extend(["<|endoftext|>", "<|endofcomment|>"])
     json.dump(dict(zip(symbols, range(len(symbols)))), encoder_outfile)
 
 


### PR DESCRIPTION
See https://github.com/gcooper-isi/subword-nmt/issues/3